### PR TITLE
fix incorrect ABI check macro name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,6 +119,7 @@ DEF-arm64-FreeBSD  = $(DEF-arm64) -DTARGETOS_FreeBSD
 DEF-arm64-NetBSD   = $(DEF-arm64) -DTARGETOS_NetBSD
 DEF-arm64-OpenBSD  = $(DEF-arm64) -DTARGETOS_OpenBSD
 DEF-riscv64        = -DTCC_TARGET_RISCV64
+#TODO: riscv32 is not necessarily ilp32, it might be ilp32d though tcc doesn't support it
 DEF-riscv32        = -DTCC_TARGET_RISCV32 -DTCC_RISCV_ilp32
 DEF-riscv32-ilp32  = $(DEF-riscv32) -DTCC_RISCV_ilp32
 DEF-c67            = -DTCC_TARGET_C67 -w # disable warnigs

--- a/riscv32-gen.c
+++ b/riscv32-gen.c
@@ -1,7 +1,7 @@
 #ifdef TARGET_DEFS_ONLY
 
 // Number of registers available to allocator:
-#ifdef TCC_TARGET_RISCV32_ilp32
+#ifdef TCC_RISCV_ilp32
 // TODO add temporary and saved registers here once I figure out how TCC works
 #define NB_REGS 10 // a0-a7, ra, sp
 #else
@@ -68,7 +68,7 @@ ST_DATA const int reg_classes[ NB_REGS ] = {
     // Integer Function Arguments
     RC_INT | RC_R( 0 ), RC_INT | RC_R( 1 ), RC_INT | RC_R( 2 ), RC_INT | RC_R( 3 ),
     RC_INT | RC_R( 4 ), RC_INT | RC_R( 5 ), RC_INT | RC_R( 6 ), RC_INT | RC_R( 7 ),
-#ifndef TCC_TARGET_RISCV32_ilp32
+#ifndef TCC_RISCV_ilp32
     // Floating point function arguments
     RC_FLOAT | RC_F( 0 ), RC_FLOAT | RC_F( 1 ), RC_FLOAT | RC_F( 2 ), RC_FLOAT | RC_F( 3 ),
     RC_FLOAT | RC_F( 4 ), RC_FLOAT | RC_F( 5 ), RC_FLOAT | RC_F( 6 ), RC_FLOAT | RC_F( 7 ),
@@ -108,7 +108,7 @@ static int freg( int r )
 
 static int is_freg( int r )
 {
-#ifndef TCC_TARGET_RISCV32_ilp32
+#ifndef TCC_RISCV_ilp32
     return r >= 8 && r < 16;
 #else
     // there are no floating point registers in rv32imc isa

--- a/tcc.h
+++ b/tcc.h
@@ -335,7 +335,7 @@ extern long double strtold (const char *__nptr, char **__endptr);
 # elif defined(TCC_TARGET_RISCV64) 
 #  define CONFIG_TCC_ELFINTERP "/lib/ld-linux-riscv64-lp64d.so.1"
 # elif defined(TCC_TARGET_RISCV32)
-#  if defined TCC_RISCV32_ilp32
+#  if defined TCC_RISCV_ilp32
 #   define CONFIG_TCC_ELFINTERP "/lib/ld-linux-riscv32-ilp32.so.1"
 #  else
 #   define CONFIG_TCC_ELFINTERP "/lib/ld-linux-riscv32-ilp32d.so.1"


### PR DESCRIPTION
When compiling riscv32-ilp32, only TCC_RISCV_ilp32 is defined. This also correct the interpreter path.