### PR TITLE
Coa/rmr/gc/2

### DIFF
--- a/riscv32-gen.c
+++ b/riscv32-gen.c
@@ -81,7 +81,7 @@ ST_DATA const int reg_classes[ NB_REGS ] = {
     RC_INT | RC_FLOAT | RC_R( 5 ) | RC_F( 5 ),
     RC_INT | RC_FLOAT | RC_R( 6 ) | RC_F( 6 ),
     RC_INT | RC_FLOAT | RC_R( 7 ) | RC_F( 7 ),
-#else 
+#else
     // Integer Function Arguments
     RC_INT | RC_R( 0 ), RC_INT | RC_R( 1 ),
     RC_INT | RC_R( 2 ), RC_INT | RC_R( 3 ),
@@ -913,7 +913,7 @@ ST_FUNC void gfunc_call( int nb_args )
                 vpushv( vtop );
             }
             vtop->type.t = loadt | ( vtop->type.t & VT_UNSIGNED );
-            gv( is_ireg(r) ? RC_R( r ) : RC_F( r ) );
+            gv( r < 8 ? RC_R( r ) : RC_F( r ) );
             vtop->type = origtype;
 
             if( r2 && loadt != VT_LLONG && loadt != VT_DOUBLE ) {
@@ -950,6 +950,14 @@ ST_FUNC void gfunc_call( int nb_args )
                 // ES(0x23, 3, 2, ireg(vtop->r2), splitofs); // sd t0, ofs(sp)
                 emit_SW( ireg( vtop->r2 ), 5, splitofs );
                 vtop->r2 = VT_CONST;
+            }
+            else if( loadt == VT_LLONG && vtop->r2 != r2 ) {
+                assert( vtop->r2 <= 7 && r2 <= 7 );
+                /* XXX we'd like to have 'gv' move directly into
+                   the right class instead of us fixing it up.  */
+                // mv Ra+1, RR2
+                emit_MV( ireg( r2 ), ireg( vtop->r2 ) );
+                vtop->r2 = r2;
             }
         done:
             vrott( i + 1 );

--- a/riscv32-gen.c
+++ b/riscv32-gen.c
@@ -682,7 +682,7 @@ static void reg_pass_rec( CType *type, int *rc, int *fieldofs, int ofs )
                 rc[ 0 ] = -1;
         }
     }
-    else if( rc[ 0 ] == 2 || rc[ 0 ] < 0 || c_type == VT_LDOUBLE )
+    else if( rc[ 0 ] == 2 || rc[ 0 ] < 0 || c_type == VT_LDOUBLE || c_type == VT_LLONG )
         rc[ 0 ] = -1;
     else if( !rc[ 0 ] || rc[ 1 ] == RC_FLOAT || is_float( c_type ) ) {
         if ( c_type == VT_LDOUBLE ) {
@@ -802,7 +802,7 @@ ST_FUNC void gfunc_call( int nb_args )
                 else {
                     /* Only half of the last arg can be transferred by reg */
                     info[ i ] |= 16;
-                    stack_adj += 8;
+                    stack_adj += 4;
                 }
                 if( !byref ) {
                     assert( ( fieldofs[ 2 ] >> 4 ) < 2048 );
@@ -901,6 +901,7 @@ ST_FUNC void gfunc_call( int nb_args )
                 /* only half of the arg is in the reg */
                 assert( !r2 );
                 /* use a reg x1 to push the other half of this arg to stack */
+                /* FIXME: It seems that this r2 will be ignored. Maybe delete this? */
                 r2 = 1 + TREG_RA; // r2 will be decreased by 1 later. so add 1 here
             }
             if( loadt == VT_LLONG || loadt == VT_DOUBLE ) {
@@ -913,7 +914,7 @@ ST_FUNC void gfunc_call( int nb_args )
                 vpushv( vtop );
             }
             vtop->type.t = loadt | ( vtop->type.t & VT_UNSIGNED );
-            gv( r < 8 ? RC_R( r ) : RC_F( r ) );
+            gv( is_ireg(r) ? RC_R( r ) : RC_F( r ) );
             vtop->type = origtype;
 
             if( r2 && loadt != VT_LLONG && loadt != VT_DOUBLE ) {
@@ -947,12 +948,11 @@ ST_FUNC void gfunc_call( int nb_args )
                 vtop->r2 = r2;
             }
             if( info[ nb_args - 1 - i ] & 16 ) {
-                // ES(0x23, 3, 2, ireg(vtop->r2), splitofs); // sd t0, ofs(sp)
-                emit_SW( ireg( vtop->r2 ), 5, splitofs );
+                emit_SW(2, ireg( vtop->r2 ),  splitofs ); // sw r2, splitofs(sp)
                 vtop->r2 = VT_CONST;
             }
             else if( loadt == VT_LLONG && vtop->r2 != r2 ) {
-                assert( vtop->r2 <= 7 && r2 <= 7 );
+                assert( is_ireg(vtop->r2)&& r2 <= 7 );
                 /* XXX we'd like to have 'gv' move directly into
                    the right class instead of us fixing it up.  */
                 // mv Ra+1, RR2

--- a/riscv32-gen.c
+++ b/riscv32-gen.c
@@ -942,7 +942,7 @@ ST_FUNC void gfunc_call( int nb_args )
 
                 save_reg_upstack( r2, 1 );
                 vtop->type.t = loadt | ( vtop->type.t & VT_UNSIGNED );
-                load( r2, vtop );
+                load( r2, vtop ); //TODO: check this
                 assert( r2 < VT_CONST );
                 vtop--;
                 vtop->r2 = r2;
@@ -956,7 +956,7 @@ ST_FUNC void gfunc_call( int nb_args )
                 /* XXX we'd like to have 'gv' move directly into
                    the right class instead of us fixing it up.  */
                 // mv Ra+1, RR2
-                emit_MV( ireg( r2 ), ireg( vtop->r2 ) );
+                emit_MV( ireg(TREG_R(r2)) , ireg( vtop->r2 ) );
                 vtop->r2 = r2;
             }
         done:

--- a/tccgen.c
+++ b/tccgen.c
@@ -319,11 +319,6 @@ static int RC2_TYPE(int t, int rc)
 #endif
     if (rc & RC_FLOAT)
         return RC_FLOAT;
-// advance to the next register class for two argument calls
-#if defined TCC_TARGET_RISCV32 || defined TCC_TARGET_RISCV32
-    if (rc > RC_FLOAT)
-        return rc << 1;
-#endif
     return RC_INT;
 }
 
@@ -6707,7 +6702,7 @@ static void gfunc_return(CType *func_type)
         ret_nregs = gfunc_sret(func_type, func_var, &ret_type,
                                &ret_align, &regsize);
         if (ret_nregs < 0) {
-#if defined TCC_TARGET_RISCV64 || defined TCC_TARGET_RISCV32
+#ifdef TCC_TARGET_RISCV64
             arch_transfer_ret_regs(0);
 #endif
         } else if (0 == ret_nregs) {


### PR DESCRIPTION
Correct the following program
```c
#include <stdio.h>

void f1(unsigned long long a){
    printf("%llx\n", a);
}

int main(){
    f1(0xc0ffeeff00001234);
    return 0;
}
```
and
```c
#include <stdio.h>
// last should be spilt into [a7] and stack
void many_args(int a0, int a1, int a2, int a3, int a4, int a5, int a6, unsigned long long last) {
    printf("last = %llx\n", last);
}

int main() {
    many_args(0, 1, 2, 3, 4, 5, 6, 0x0f0e1234dd003300ULL);
    return 0;
}
```
Maybe we should add the second one to tests? 