### PR TITLE
Refine in floating point operations

### DIFF
--- a/riscv32-gen.c
+++ b/riscv32-gen.c
@@ -1052,7 +1052,7 @@ ST_FUNC void gfunc_prolog( Sym *func_sym )
                 else if( prc[ 1 + i ] == RC_FLOAT ) {
                     // emit_S(0x22, (size / regcount) == 4 ? 2 : 3, 8, 10 + areg[1]++, loc +
                     // (fieldofs[i+1] >> 4)); // fs[wd] FAi, loc(s0)
-                    tcc_warning( "experimental floating point support" );
+                    printf( "experimental floating point support" );
                     emit_SW( s0, freg( TREG_F(areg[ 1 ]++) ), loc + i * XLEN ); //todo: check this
                 }
                 else {

--- a/riscv32-gen.c
+++ b/riscv32-gen.c
@@ -1688,8 +1688,7 @@ ST_FUNC void gen_opf(int op) {
             printf("[gen_opf]: type = long double\n");
             break;
         default:
-            tcc_error("unsuported floating point type: '%s'",
-            get_tok_str(tok, NULL));
+            tcc_error("unsuported floating point type: %d", type);
             break;
     }
 
@@ -1717,8 +1716,6 @@ ST_FUNC void gen_opf(int op) {
         vtop->r2 = REG_FRE2;
     else
         vtop->r2 = VT_CONST;
-
-    tcc_warning("Floating point is in alpha on riscv32");
 }
 
 ST_FUNC void gen_cvt_sxtw( void )
@@ -1751,24 +1748,22 @@ ST_FUNC void gen_cvt_itof( int t )
         case VT_DOUBLE:  float_type = 1; break;
         case VT_LDOUBLE: float_type = 2; break;
         default:
-            tcc_error("unsuported floating point type: '%s'",
-            get_tok_str(tok, NULL));
+            tcc_error("unsuported floating point type: %d", t);
             return;
     }
 
     switch (type) {
+        case VT_BYTE:
+        case VT_SHORT:
         case VT_INT:
+        case VT_LONG:
             float_op = is_unsigned ?  FLOAT_OP_UNSI_F : FLOAT_OP_SI_F;
             break;
-        case VT_LONG:
+        case VT_LLONG:
             float_op = is_unsigned ? FLOAT_OP_UNDI_F : FLOAT_OP_DI_F;
             break;
-        case VT_LLONG:
-            float_op = is_unsigned ? FLOAT_OP_UNTI_F : FLOAT_OP_TI_F;
-            break;
         default:
-            tcc_error("unsuported type for fp conversion: '%s'",
-            get_tok_str(tok, NULL));
+            tcc_error("unsuported type for itof conversion: %d" , type);
             return;
     }
 
@@ -1799,8 +1794,7 @@ ST_FUNC void gen_cvt_ftoi( int t )
         case VT_DOUBLE:  float_op = FLOAT_OP_DF_I; break;
         //case VT_LDOUBLE: float_type = 2; break; // rv32 doesn't support long double
         default:
-            tcc_error("unsuported floating point type: '%s'",
-            get_tok_str(tok, NULL));
+            tcc_error("unsuported floating point type: %d", type);
             return;
     }
     switch (t & VT_BTYPE) {
@@ -1812,8 +1806,7 @@ ST_FUNC void gen_cvt_ftoi( int t )
             int_type = 1;;
         break;
         default:
-            tcc_error("unsuported type for fp conversion: '%s'",
-            get_tok_str(tok, NULL));
+            tcc_error("unsuported type for ftoi conversion: %d", t);
             return;
     }
 
@@ -1844,8 +1837,7 @@ ST_FUNC void gen_cvt_ftof(int dest_type)
         case VT_DOUBLE:  source_type_idx = 1; break;
         case VT_LDOUBLE: source_type_idx = 2; break;
         default:
-            tcc_error("unsuported floating point type: '%s'",
-            get_tok_str(tok, NULL));
+            tcc_error("unsuported floating point type: %d", source_type);
             return;
     }
 
@@ -1854,8 +1846,7 @@ ST_FUNC void gen_cvt_ftof(int dest_type)
         case VT_DOUBLE:  dest_type_idx = FLOAT_OP_DF_F; break;
         case VT_LDOUBLE: dest_type_idx = FLOAT_OP_TF_F; break;
         default:
-            tcc_error("unsuported floating point type: '%s'",
-            get_tok_str(tok, NULL));
+            tcc_error("unsuported floating point type: %d", dest_type);
             return;
     }
 

--- a/riscv32-gen.c
+++ b/riscv32-gen.c
@@ -277,6 +277,7 @@ static void load_lvalue( int r, SValue *sv )
     int dest_reg = is_ireg( r ) ? ireg( r ) : freg( r ); // rr
     int lvar_offset = sv->c.i;                           // fc
     int stack_type = sv->type.t & VT_BTYPE;              // bt
+    int is_unsigned = (sv->type.t & VT_UNSIGNED) != 0;
     int stack_reg = sv->r;                               // fr
     int masked_stack_reg = stack_reg & VT_VALMASK;       // v
     int align;
@@ -343,11 +344,20 @@ static void load_lvalue( int r, SValue *sv )
         tcc_error("[internal error] load sizes > %d bytes should be on the stack", 2*XLEN);
     }
     // TODO handle floating pont, 64-bit values, and 128-bit values
-    switch( size ) {
-        case 1: emit_LB( dest_reg, rs1, lvar_offset ); break;
-        case 2: emit_LH( dest_reg, rs1, lvar_offset ); break;
-        case 4: emit_LW( dest_reg, rs1, lvar_offset ); break;
-        default: tcc_error( "unexpected load size: %d", size );
+    if (is_unsigned) {
+        switch( size ) {
+            case 1: emit_LBU( dest_reg, rs1, lvar_offset ); break;
+            case 2: emit_LHU( dest_reg, rs1, lvar_offset ); break;
+            case 4: emit_LW( dest_reg, rs1, lvar_offset ); break;
+            default: tcc_error( "unexpected load size: %d", size );
+        }
+    }else {
+        switch( size ) {
+            case 1: emit_LB( dest_reg, rs1, lvar_offset ); break;
+            case 2: emit_LH( dest_reg, rs1, lvar_offset ); break;
+            case 4: emit_LW( dest_reg, rs1, lvar_offset ); break;
+            default: tcc_error( "unexpected load size: %d", size );
+        }
     }
 }
 

--- a/riscv32-gen.c
+++ b/riscv32-gen.c
@@ -1608,11 +1608,9 @@ enum FLOAT_OP_TYPE {
     // signed integer -> float
     FLOAT_OP_SI_F,
     FLOAT_OP_DI_F,
-    FLOAT_OP_TI_F,
     // unsigned integer -> float
     FLOAT_OP_UNSI_F,
     FLOAT_OP_UNDI_F,
-    FLOAT_OP_UNTI_F,
     // conversion between different floating point types
     FLOAT_OP_SF_F,
     FLOAT_OP_DF_F,
@@ -1646,11 +1644,9 @@ static const int float_funcs[][3] = {
     // conversion functions for signed integers
     {TOK___floatsisf, TOK___floatsidf, TOK___floatsitf},
     {TOK___floatdisf, TOK___floatdidf, TOK___floatditf},
-    {TOK___floattisf, TOK___floattidf, TOK___floattitf},
     // conversion functions for unsigned integers
     {TOK___floatunsisf, TOK___floatunsidf, TOK___floatunsitf},
     {TOK___floatundisf, TOK___floatundidf, TOK___floatunditf},
-    {TOK___floatuntisf, TOK___floatuntidf, TOK___floatuntitf},
     // conversion between different floating point types
     {TOK_ASM_nop,       TOK___truncdfsf2,  TOK___trunctfsf2},
     {TOK___extendsfdf2, TOK_ASM_nop,       TOK___trunctfdf2},

--- a/tcctok.h
+++ b/tcctok.h
@@ -372,26 +372,18 @@
      DEF(TOK___floatsisf, "__floatsisf")
      DEF(TOK___floatsidf, "__floatsidf")
      //DEF(TOK___floatsitf, "__floatsitf")
-     // signed long -> float, double, long double
+     // signed long long -> float, double, long double
      DEF(TOK___floatdisf, "__floatdisf")
      DEF(TOK___floatdidf, "__floatdidf")
      //DEF(TOK___floatditf, "__floatditf")
-     // signed long long -> float, double, long double
-     DEF(TOK___floattisf, "__floattisf")
-     DEF(TOK___floattidf, "__floattidf")
-     DEF(TOK___floattitf, "__floattitf")
      // unsigned int -> float, double, long double
      DEF(TOK___floatunsisf, "__floatunsisf")
      DEF(TOK___floatunsidf, "__floatunsidf")
      DEF(TOK___floatunsitf, "__floatunsitf")
-     // unsigned long -> float, double, long double
+     // unsigned long long -> float, double, long double
      //DEF(TOK___floatundisf, "__floatundisf")
      //DEF(TOK___floatundidf, "__floatundidf")
      DEF(TOK___floatunditf, "__floatunditf")
-     // unsigned long long -> float, double, long double
-     DEF(TOK___floatuntisf, "__floatuntisf")
-     DEF(TOK___floatuntidf, "__floatuntidf")
-     DEF(TOK___floatuntitf, "__floatuntitf")
 
      // conversion between shorter -> longer floating point type 
      DEF(TOK___extendsfdf2, "__extendsfdf2")

--- a/tests/tests2/Makefile
+++ b/tests/tests2/Makefile
@@ -54,22 +54,16 @@ ifneq (,$(filter OpenBSD FreeBSD NetBSD,$(TARGETOS)))
 endif
 ifeq ($(ARCH),riscv32)
  SKIP += 22_floating_point.test
- SKIP += 23_type_coercion.test
- SKIP += 24_math_library.test
- SKIP += 49_bracket_evaluation.test
  SKIP += 70_floating_point_literals.test
- SKIP += 73_arm64.test # contains floating stuff
- SKIP += 83_utf8_in_identifiers.test # contains floating stuff
+ SKIP += 73_arm64.test # long double
  SKIP += 93_integer_promotion.test # do we follow gcc on x86_64 or riscv?
- SKIP += 94_generic.test # contains floating stuff
  SKIP += 95_bitfields.test # more bitfield nonsense
  SKIP += 95_bitfields_ms.test # more bitfield nonsense
  SKIP += 96_nodata_wanted.test # floating point
  SKIP += 101_cleanup.test # floating point
  SKIP += 107_stack_safe.test # floating point
- SKIP += 109_float_struct_calling.test # floating point
- SKIP += 110_average.test # floating point
- SKIP += 111_conversion.test # floating point
+ SKIP += 109_float_struct_calling.test
+ SKIP += 111_conversion.test # long double 
  SKIP += 112_backtrace.test # no bounds checking
  SKIP += 113_btdll.test # need to build those libraries still
  SKIP += 114_bound_signal.test # no bounds checking


### PR DESCRIPTION
* Use lwu and lbu in load_lvalue when loading unsigned type
* Remove i128 related fp conversion in rv32 ( as libgcc_s.so doesn't support them on rv32)
* Also refactor the error output in fp op
* Enable more floating point related tests