### PR TITLE
fix va_args support

### DIFF
--- a/conftest.c
+++ b/conftest.c
@@ -14,6 +14,8 @@ const char *platform_macros[] = {
     "__arm__",              "TCC_TARGET_ARM",
     "__ARM_EABI__",         "TCC_ARM_EABI",
     "__aarch64__",          "TCC_TARGET_ARM64",
+    /* Both riscv32 and riscv64 define __riscv =1 so we add an artificial define here */
+    "__riscv32",            "TCC_TARGET_RISCV32",
     "__riscv",              "TCC_TARGET_RISCV64",
     "__APPLE__",            "TCC_TARGET_MACHO",
     "__FreeBSD__",          "TARGETOS_FreeBSD",

--- a/include/tccdefs.h
+++ b/include/tccdefs.h
@@ -229,7 +229,7 @@
     } __builtin_va_list;
 
 #endif
-#elif defined __riscv
+#elif defined __riscv || defined __riscv32
     typedef char *__builtin_va_list;
     #define __va_reg_size (__riscv_xlen >> 3)
     #define _tcc_align(addr,type) (((unsigned long)addr + __alignof__(type) - 1) \

--- a/riscv32-gen.c
+++ b/riscv32-gen.c
@@ -982,9 +982,9 @@ ST_FUNC void gfunc_prolog( Sym *func_sym )
     CType *type;
 
     sym = func_type->ref;
-    loc = -16; // for ra and s0
+    loc = -XLEN * 2; // for ra and s0
     func_sub_sp_offset = ind;
-    ind += 5 * 4;
+    ind += 5 * 4; // skip stack expand now, to be filled in gfunc_epilog
 
     areg[ 0 ] = 0;
     areg[ 1 ] = 0;
@@ -1012,7 +1012,7 @@ ST_FUNC void gfunc_prolog( Sym *func_sym )
         size = type_size( type, &align );
         if( size > 2 * XLEN ) {
             type = &char_pointer_type;
-            size = align = byref = 8;
+            size = align = byref = XLEN;
         }
         reg_pass( type, prc, fieldofs, 1 );
         regcount = prc[ 0 ];
@@ -1027,8 +1027,8 @@ ST_FUNC void gfunc_prolog( Sym *func_sym )
             addr += size;
         }
         else {
-            loc -= regcount * 8; // XXX could reserve only 'size' bytes
-            // loc -= regcount * PTR_SIZE; // XXX could reserve only 'size' bytes
+            loc -= regcount * XLEN;
+
             param_addr = loc;
             for( i = 0; i < regcount; i++ ) {
                 const uint32_t t0 = 5;
@@ -1059,8 +1059,7 @@ ST_FUNC void gfunc_prolog( Sym *func_sym )
         const uint32_t s0 = 8;
         for( ; areg[ 0 ] < 8; areg[ 0 ]++ ) {
             num_va_regs++;
-            // ES(0x23, 2, 8, 10 + areg[0], -8 + num_va_regs * 8); // sw aX, loc(s0)
-            emit_SW( s0, ireg( areg[ 0 ] ), -8 + num_va_regs * 8 );
+            emit_SW( s0, ireg( TREG_R(areg[ 0 ]) ), -XLEN + num_va_regs * XLEN );
         }
     }
 #ifdef CONFIG_TCC_BCHECK


### PR DESCRIPTION
tested with
```c
#include <stdarg.h>
#include "stdio.h"

static void printint2(int fd, int xx, int base, int sgn) {
    printf("%d",xx);
}
void vprintf2(int fd, const char *fmt, va_list ap) {
    char *s;
    int   c, i, state;

    state = 0;
    for (i = 0; fmt[i]; i++) {
        c = fmt[i] & 0xff;
        if (state == 0) {
            if (c == '%') {
                state = '%';
            } else {
            }
        } else if (state == '%') {
            if (c == 'd') {
                printint2(fd, va_arg(ap, int), 10, 1);
            }
            state = 0;
        }
    }
}


void printf2(const char *fmt, ...) {
    va_list ap;

    va_start(ap, fmt);
    vprintf2(1, fmt, ap);
    va_end(ap);
}

int main(){
    printf2("%d", 4);
}
```

conftest need to generate `TCC_TARGET_RISCV32` in tccdefs_.h, otherwise `__builtin_va_start` will be replaced by macro, and `parse_builtin_params` will never be called.