### PR TITLE
allow save_reg_upstack to save LLONG to stack

### DIFF
--- a/riscv32-gen.c
+++ b/riscv32-gen.c
@@ -507,7 +507,8 @@ ST_FUNC void store( int r, SValue *sv )
     if( size > 8 ) {
         tcc_error( "unimp: large sized store" );
     }
-    if (stack_type == VT_DOUBLE) {
+    // caller takes the responsibility for splitting anything that USING_TWO_WORDS
+    if (stack_type == VT_DOUBLE || stack_type == VT_LLONG) {
         size = align = 4;
     }
     if (is_float(stack_type)){
@@ -1817,7 +1818,7 @@ ST_FUNC void gen_cvt_ftoi( int t )
     gfunc_call( 1 );
     vpushi( 0 );
     vtop->r = REG_IRET;
-    if (t == VT_LLONG)
+    if ((t & VT_BTYPE) == VT_LLONG)
         vtop->r2 = REG_IRE2;
     else
         vtop->r2 = VT_CONST;


### PR DESCRIPTION
tested with
```c
extern int printf(const char *, ...);

static void func_ull_ull(unsigned long long l1,unsigned long long l2){
}

int main()
{
  int a,b,c,d;
  a=1;b=2;c=3;d=4;
  func_ull_ull((unsigned long long)a/1.0,(unsigned long long)b/1.0);
  printf("%d %d %d %d",a,b,c,d);
  return 0;
}
```