### PR TITLE
fix(riscv32-gen.c): fix wrong instruction for srai

### DIFF
--- a/riscv32-gen.c
+++ b/riscv32-gen.c
@@ -1519,8 +1519,8 @@ static int gen_opi_immediate( int op, int fc, int ll )
             emit_SRLI( rd, a, fc );
             break;
         case TOK_SAR:
-            fc = 1024 | ( fc & m );
-            emit_SRA( rd, a, fc );
+            fc &= m;
+            emit_SRAI( rd, a, fc );
             break;
 
 


### PR DESCRIPTION
In the riscv64-gen implementation, the value 1024 was previously used to manually set the `function6` field for I-type instructions. However, since emit_SRAI already handles this setting, we no longer need to set it explicitly.
Also, emit_SRAI should be used instead of emit_SRA here.