### PR TITLE
fix(riscv32-gen.c): do not overwrite s0

### DIFF
--- a/riscv32-gen.c
+++ b/riscv32-gen.c
@@ -243,9 +243,9 @@ static int load_symofs( int r, SValue *sv, int forstore )
         }
         if( LARGE_IMM( sv_constant ) ) {
             int s1 = 9;
-            emit_LI( s1, sv_constant );
+            emit_LUI( s1, IMM_HIGH_LEXT(sv_constant) );
             emit_ADD( s1, s0, s1);
-            sv->c.i = 0;
+            sv->c.i = IMM_LOW(sv_constant);
             rd = s1;
         }
     }

--- a/riscv32-gen.c
+++ b/riscv32-gen.c
@@ -3,6 +3,7 @@
 // Number of registers available to allocator:
 #ifdef TCC_RISCV_ilp32
 // TODO add temporary and saved registers here once I figure out how TCC works
+// NOTE: s0 is used as fp and s1 is used as tmp reg in load_symofs
 #define NB_REGS 17 // t0-t6, a0-a7, ra, sp, (fa0-fa7) aliases for a0-a7
 #else
 #define NB_REGS 26 // t0-t6, a0-a7, fa0-fa7, xxx, ra, sp
@@ -235,14 +236,12 @@ static int load_symofs( int r, SValue *sv, int forstore )
     }
     // if the stack value is a pointer
     else if( stack_value == VT_LOCAL || stack_value == VT_LLOCAL ) {
-        int s0;
-        s0 = 8; // s0
+        int s0 = 8;
         rd = s0;
         if( sv_constant != sv->c.i ) {
-            tcc_error( "unimp: store(giant local off) (0x%lx)", (long)sv->c.i );
+            tcc_error( "unimp: store(giant local off) (0x%lx)", sv->c.i );
         }
         if( LARGE_IMM( sv_constant ) ) {
-            // sv->c.i = IMM_LOW( sv_constant );
             int s1 = 9;
             emit_LI( s1, sv_constant );
             emit_ADD( s1, s0, s1);

--- a/riscv32-gen.c
+++ b/riscv32-gen.c
@@ -243,7 +243,11 @@ static int load_symofs( int r, SValue *sv, int forstore )
         }
         if( LARGE_IMM( sv_constant ) ) {
             // sv->c.i = IMM_LOW( sv_constant );
-            emit_LI( rd, sv_constant );
+            int s1 = 9;
+            emit_LI( s1, sv_constant );
+            emit_ADD( s1, s0, s1);
+            sv->c.i = 0;
+            rd = s1;
         }
     }
     else {

--- a/riscv_utils.h
+++ b/riscv_utils.h
@@ -33,7 +33,10 @@ void emit_J( uint32_t imm, uint32_t rd, uint32_t opcode );
 
 // Macros for masking values for immediate operations
 // mask off the lower 12 bits of a 32-bit value
-#define IMM_LOW( imm ) ( ( imm ) & 0x00000FFF )
+#define IMM_LOW(imm) ((int32_t)((imm) << 20) >> 20)
+// NOTE: the following one is only suitable for emit_XXX since
+// it will ignore signedness
+// #define IMM_LOW( imm ) ( ( imm ) & 0x00000FFF )
 // mask and shift a 32-bit immediate value to grab the upper 24 bits
 #define IMM_HIGH( imm ) ( ( ( imm ) & 0xFFFFF000 ) >> 12 )
 // like IMM_HIGH but with lower sign extended bits considered


### PR DESCRIPTION
Do not clobber s0 in `load_symofs` since it holds frame pointer.
Also add the missing ADD back, which got removed in df8b521

Preferred merge strategy: squash