### PR TITLE
allow returning empty struct in rv32_ilp32

### DIFF
--- a/riscv32-gen.c
+++ b/riscv32-gen.c
@@ -1094,9 +1094,11 @@ ST_FUNC int gfunc_sret( CType *vt, int variadic, CType *ret, int *ret_align, int
     nregs = prc[ 0 ];
     if( nregs == 2 && prc[ 1 ] != prc[ 2 ] )
         return -1; /* generic code can't deal with this case */
+#ifndef TCC_RISCV_ilp32
     if( prc[ 1 ] == RC_FLOAT ) {
         *regsize = size / nregs;
     }
+#endif
     ret->t = fieldofs[ 1 ] & VT_BTYPE;
     ret->ref = NULL;
     return nregs;


### PR DESCRIPTION
a follow-up of 84cfb5. Since RC_FLOAT is now equal to RC_INT There is no need to recalculate the regsize, which will cause the tcc to crash when return an empty struct/union. Since nregs is zero(the size of an empty struct/union is zero in C)

tested with
```c
struct zero_struct {};

struct zero_struct tst_zero_struct(void)
{
  struct zero_struct ret;
  return ret;
}
int main(){}
```